### PR TITLE
Implement flavor prefixes

### DIFF
--- a/appexample/build.gradle.kts
+++ b/appexample/build.gradle.kts
@@ -36,10 +36,15 @@ dependencies {
 
 poeditor {
 	apiKey = System.getenv("UBIQUE_POEDITOR_API_KEY") ?: extra["ubiquePoEditorAPIKey"] as? String
-	projectId = "394599"
+	projectId = "234253"
 	defaultLanguage = "en"
 	fallbackLanguage = "de"
 	resourceDir = layout.buildDirectory.file("poeditor-output")
 	fileName = "strings.xml"
 	exportOptions = null
+	flavorPrefixes = mapOf(
+		"onboarding" to layout.buildDirectory.file("poeditor-output-onboarding").get(),
+		"gafor" to layout.buildDirectory.file("poeditor-output-gafor").get(),
+	)
+	flavorPrefixSeparator = "_"
 }

--- a/poeditor/plugin/src/main/kotlin/ch/ubique/gradle/poeditor/PoEditorPlugin.kt
+++ b/poeditor/plugin/src/main/kotlin/ch/ubique/gradle/poeditor/PoEditorPlugin.kt
@@ -5,6 +5,7 @@ import ch.ubique.gradle.poeditor.task.PoEditorAddTermTask
 import ch.ubique.gradle.poeditor.task.PoEditorPullTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import kotlin.jvm.java
 
 abstract class PoEditorPlugin : Plugin<Project> {
 
@@ -24,6 +25,8 @@ abstract class PoEditorPlugin : Plugin<Project> {
 			task.resourceType = extension.resourceType.get()
 			task.filename = extension.fileName.get()
 			task.exportOptions = extension.exportOptions.orNull
+			task.flavorPrefixes = extension.flavorPrefixes.get()
+			task.flavorPrefixSeparator = extension.flavorPrefixSeparator.get()
 		}
 
 		project.tasks.register(

--- a/poeditor/plugin/src/main/kotlin/ch/ubique/gradle/poeditor/backend/PoEditorClient.kt
+++ b/poeditor/plugin/src/main/kotlin/ch/ubique/gradle/poeditor/backend/PoEditorClient.kt
@@ -9,7 +9,6 @@ import retrofit2.Call
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
-import java.io.File
 
 internal class PoEditorClient(
 	private val apiKey: String,
@@ -37,18 +36,14 @@ internal class PoEditorClient(
 		return service.languagesList(apiKey, projectId).requireResult().languages
 	}
 
-	fun export(projectId: String, code: String, fileType: String, fallbackLanguage: String?, options: String?, file: File) {
+	fun exportToXml(projectId: String, code: String, fileType: String, fallbackLanguage: String?, options: String?): String {
 		val url = service.export(apiKey, projectId, code, fileType, fallbackLanguage, options).requireResult().url
 		val request = Request.Builder().url(url).build()
 		httpClient.newCall(request).execute().use { response ->
 			if (!response.isSuccessful) {
 				throw GradleException("Failed to download translations with response ${response.code} ${response.message}")
 			}
-			file.outputStream().use { output ->
-				response.body.byteStream().use { input ->
-					input.copyTo(output)
-				}
-			}
+			return response.body.string()
 		}
 	}
 

--- a/poeditor/plugin/src/main/kotlin/ch/ubique/gradle/poeditor/config/PoEditorPluginConfig.kt
+++ b/poeditor/plugin/src/main/kotlin/ch/ubique/gradle/poeditor/config/PoEditorPluginConfig.kt
@@ -2,7 +2,9 @@ package ch.ubique.gradle.poeditor.config
 
 import ch.ubique.gradle.poeditor.api.StringsFileType
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
@@ -56,4 +58,15 @@ constructor(project: Project) {
 	 */
 	val exportOptions: Property<String> = objects.property(String::class.java).apply { set("[{\"unquoted\":1}]") }
 
+	/**
+	 * Map of flavor prefixes that will be exported to the specified directory
+	 */
+	val flavorPrefixes: MapProperty<String, RegularFile> =
+		objects.mapProperty(String::class.java, RegularFile::class.java).apply { set(emptyMap()) }
+
+	/**
+	 * The Prefix Separator will be stripped alongside the prefix from the string name. Default "_"
+	 */
+	val flavorPrefixSeparator: Property<String> =
+		objects.property(String::class.java).apply { set("_") }
 }

--- a/poeditor/plugin/src/main/kotlin/ch/ubique/gradle/poeditor/task/PoEditorPullTask.kt
+++ b/poeditor/plugin/src/main/kotlin/ch/ubique/gradle/poeditor/task/PoEditorPullTask.kt
@@ -4,8 +4,10 @@ import ch.ubique.gradle.poeditor.api.StringsFileType
 import ch.ubique.gradle.poeditor.backend.PoEditorClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFile
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
@@ -44,7 +46,18 @@ abstract class PoEditorPullTask : DefaultTask() {
 	@get:Optional
 	abstract var exportOptions: String?
 
+	@get:Internal
+	abstract var flavorPrefixes: Map<String, RegularFile>
+
+	@get:Input
+	abstract var flavorPrefixSeparator: String
+
 	private val projectDir = project.projectDir
+
+	// Matches a single <string> element and captures its `name`. Assumes each element is on
+	// its own line: multi-line elements (e.g. <plurals>, <string-array>) are not matched and
+	// are therefore always kept verbatim in the base file, never filtered or moved to a flavor.
+	private val stringNameRegex = Regex("""<string[^>]*name="([^"]+)"[^>]*>.*?</string>""")
 
 	init {
 		group = "poeditor"
@@ -65,11 +78,37 @@ abstract class PoEditorPullTask : DefaultTask() {
 
 		languages.forEach { language ->
 			val localePostfix = if (language.code == defaultLanguage) "" else "-" + language.code.toAndroidLocale()
-			val path = File(resourceDir, "$resourceType$localePostfix")
+			val localeDir = "$resourceType$localePostfix"
+
+			// Get all translations as xml
+			val xmlContent = client.exportToXml(projectId, language.code, fileType.name.lowercase(), fallbackLang, exportOptions)
+
+			// Filter out the prefixes for the base xml
+			val baseXml = filterMapXmlByStringName(xmlContent, { name ->
+				if (flavorPrefixes.keys.any { prefix -> name.startsWith(prefix + flavorPrefixSeparator) })
+					null
+				else name
+			})
+			val path = File(resourceDir, localeDir)
 			path.mkdirs()
 			val file = File(path, filename)
-			client.export(projectId, language.code, fileType.name.lowercase(), fallbackLang, exportOptions, file)
-			println("Exported ${language.name} to ${file.toRelativeString(projectDir)}")
+			file.writeText(baseXml)
+
+			// Now write only the strings associated with the prefix
+			flavorPrefixes.forEach { (prefix, dir) ->
+				val xml = filterMapXmlByStringName(xmlContent, { name ->
+					if (name.startsWith(prefix + flavorPrefixSeparator))
+						name.removePrefix(prefix + flavorPrefixSeparator)
+					else null
+				})
+
+				val path = File(dir.asFile, localeDir)
+				path.mkdirs()
+				val file = File(path, filename)
+				file.writeText(xml)
+				println("Exported ${language.name} ($prefix) to ${file.toRelativeString(projectDir)}")
+			}
+			println("Exported ${language.name} (base) to ${file.toRelativeString(projectDir)}")
 		}
 	}
 
@@ -81,4 +120,29 @@ abstract class PoEditorPullTask : DefaultTask() {
 			parts[0].lowercase() + "-r" + parts[1].uppercase()
 		}
 	}
+
+	/**
+	 * Filters and maps the XML lines using the callback. The callback receives the "name" value.
+	 * If the callback returns null, the line is dropped.
+	 * If it returns a String, the line is kept and the "name" attribute is replaced.
+	 * Lines without a valid match are kept as a default.
+	 *
+	 * Note: this operates line-by-line and only recognizes single-line <string> elements.
+	 * Multi-line elements such as <plurals> and <string-array> are always passed through
+	 * unchanged (never filtered by prefix nor moved into a flavor output).
+	 */
+	private fun filterMapXmlByStringName(xml: String, callback: (String) -> String?): String =
+		xml.lines()
+			.mapNotNull { line ->
+				// Find the regex match. If it doesn't exist, keep the line as is.
+				val match = stringNameRegex.find(line) ?: return@mapNotNull line
+
+				// Execute the callback. If it returns null, drop the line.
+				val newName = callback(match.groupValues[1]) ?: return@mapNotNull null
+
+				// Replace only the specific characters where the old name was found.
+				val nameRange = match.groups[1]!!.range
+				line.replaceRange(nameRange, newName)
+			}
+			.joinToString("\n")
 }


### PR DESCRIPTION
Flavor Prefixes allows setting custom values for build flavors by prefixing them in PoEditor.

Example:
```toml
app_title = "Welcome to MyApp"
debug_app_title = "Welcome to MyApp (Debug)"
```
will become
```xml
// main/strings.xml
<string name="app_title">Welcome to MyApp</string>

// debug/strings.xml
<string name="app_title">Welcome to MyApp (Debug)</string>
```

The prefixes, the location per prefix, and the prefix separator can all be configured:
```kotlin
// Default: emptyMap()
flavorPrefixes = mapOf(
  "debug" to layout.buildDirectory.file("example/debug").get(),
  "int" to layout.buildDirectory.file("example/int").get(),
)
// Default: "_"
flavorPrefixSeparator = "_"
```

> NOTE: This PR uses very basic xml parsing, as such multiline strings might be an issue